### PR TITLE
fix pregnancy extension typo

### DIFF
--- a/input/fsh/examples/enhancedEPI/Alicia_e_calcium.fsh
+++ b/input/fsh/examples/enhancedEPI/Alicia_e_calcium.fsh
@@ -25,7 +25,7 @@ Usage: #example
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 

--- a/input/fsh/examples/enhancedEPI/Alicia_e_hypericum.fsh
+++ b/input/fsh/examples/enhancedEPI/Alicia_e_hypericum.fsh
@@ -27,7 +27,7 @@ Usage: #example
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 

--- a/input/fsh/examples/enhancedEPI/Alicia_e_karvea.fsh
+++ b/input/fsh/examples/enhancedEPI/Alicia_e_karvea.fsh
@@ -23,7 +23,7 @@ Usage: #inline
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 
@@ -189,7 +189,7 @@ Usage: #inline
             <b>Karvea with food and drink</b>
             <p>Karvea can be taken with or without food.</p>
             <b>Pregnancy and breast-feeding</b>
-            <span class="pregancyCategory highlight"> 
+            <span class="pregnancyCategory highlight"> 
             <b>Pregnancy</b>
             <p>You must tell your doctor if you think you are (or might become) pregnant. Your doctor will normally advise you to stop taking Karvea before you become pregnant or as soon as you know you are pregnant and will advise you to take another medicine instead of Karvea. Karvea is not recommended in early pregnancy, and must not be taken when more than 3 months pregnant, as it may cause serious harm to your baby if used after the third month of pregnancy.</p>
             </span>

--- a/input/fsh/examples/enhancedEPI/Pedro_e_calcium.fsh
+++ b/input/fsh/examples/enhancedEPI/Pedro_e_calcium.fsh
@@ -25,7 +25,7 @@ Usage: #inline
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 

--- a/input/fsh/examples/enhancedEPI/Pedro_e_hypericum.fsh
+++ b/input/fsh/examples/enhancedEPI/Pedro_e_hypericum.fsh
@@ -30,7 +30,7 @@ Usage: #inline
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 

--- a/input/fsh/examples/enhancedEPI/Pedro_e_karvea.fsh
+++ b/input/fsh/examples/enhancedEPI/Pedro_e_karvea.fsh
@@ -23,7 +23,7 @@ Usage: #inline
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 
@@ -189,7 +189,7 @@ Usage: #inline
             <b>Karvea with food and drink</b>
             <p>Karvea can be taken with or without food.</p>
             <b>Pregnancy and breast-feeding</b>
-            <span class="pregancyCategory collapse"> 
+            <span class="pregnancyCategory collapse"> 
             <b>Pregnancy</b>
             <p>You must tell your doctor if you think you are (or might become) pregnant. Your doctor will normally advise you to stop taking Karvea before you become pregnant or as soon as you know you are pregnant and will advise you to take another medicine instead of Karvea. Karvea is not recommended in early pregnancy, and must not be taken when more than 3 months pregnant, as it may cause serious harm to your baby if used after the third month of pregnancy.</p>
             </span>

--- a/input/fsh/examples/processedEPI/p_calcium.fsh
+++ b/input/fsh/examples/processedEPI/p_calcium.fsh
@@ -25,7 +25,7 @@ Usage: #example
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 

--- a/input/fsh/examples/processedEPI/p_hypericum.fsh
+++ b/input/fsh/examples/processedEPI/p_hypericum.fsh
@@ -30,7 +30,7 @@ Usage: #example
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 

--- a/input/fsh/examples/processedEPI/p_karvea.fsh
+++ b/input/fsh/examples/processedEPI/p_karvea.fsh
@@ -24,7 +24,7 @@ Usage: #inline
 
 * extension[+].url = "http://hl7.org/fhir/uv/emedicinal-product-info/StructureDefinition/HtmlElementLink"
 * extension[=].extension[+].url = "elementClass"
-* extension[=].extension[=].valueString = "pregancyCategory"
+* extension[=].extension[=].valueString = "pregnancyCategory"
 * extension[=].extension[+].url = "concept"
 * extension[=].extension[=].valueCodeableReference.concept.coding = http://snomed.info/sct#77386006 "Pregnancy"
 
@@ -190,7 +190,7 @@ Usage: #inline
             <b>Karvea with food and drink</b>
             <p>Karvea can be taken with or without food.</p>
             <b>Pregnancy and breast-feeding</b>
-            <span class="pregancyCategory"> 
+            <span class="pregnancyCategory"> 
             <b>Pregnancy</b>
             <p>You must tell your doctor if you think you are (or might become) pregnant. Your doctor will normally advise you to stop taking Karvea before you become pregnant or as soon as you know you are pregnant and will advise you to take another medicine instead of Karvea. Karvea is not recommended in early pregnancy, and must not be taken when more than 3 months pregnant, as it may cause serious harm to your baby if used after the third month of pregnancy.</p>
             </span>


### PR DESCRIPTION
The pregnancyCategory extension presented typos in some preprocessed and enhanced ePIs. A "n" Character was missing and now it is included.